### PR TITLE
Generate classes with Jakarta namespace and build with java 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 The XSD2Java Gradle Plugin generates java classes from an existing XSD schema. For this it uses the existing ANT task.
 
 > [!NOTE]
-> To use javax namespace, you must use a version < 3.1.0 of this plugin. From 3.1.0 it uses the jakarta namespace for xml.
+> To use javax namespace, you must use a version < 3.1.0 of this plugin. From 3.1.0 it uses the jakarta namespace for xml bindings.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 The XSD2Java Gradle Plugin generates java classes from an existing XSD schema. For this it uses the existing ANT task.
 
+[!NOTE]
+To use javax namespace, you must use a version < 3.1.0 of this plugin. From 3.1.0 it uses the jakarta namespace for xml.
+
 ## Usage
 
 Build script snippet for use in all Gradle versions:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'de.qaware.gradle.plugin:xsd2java-gradle-plugin:3.0.0'
+        classpath 'de.qaware.gradle.plugin:xsd2java-gradle-plugin:3.1.0'
     }
 }
 
@@ -28,7 +28,7 @@ apply plugin: 'de.qaware.gradle.plugin.xsd2java'
 Build script snippet for new, incubating, plugin mechanism introduced in Gradle 2.1:
 ```groovy
 plugins {
-    id 'de.qaware.gradle.plugin.xsd2java' version '3.0.0'
+    id 'de.qaware.gradle.plugin.xsd2java' version '3.1.0'
 }
 ```
 ## Tasks

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 The XSD2Java Gradle Plugin generates java classes from an existing XSD schema. For this it uses the existing ANT task.
 
-[!NOTE]
-To use javax namespace, you must use a version < 3.1.0 of this plugin. From 3.1.0 it uses the jakarta namespace for xml.
+> [!NOTE]
+> To use javax namespace, you must use a version < 3.1.0 of this plugin. From 3.1.0 it uses the jakarta namespace for xml.
 
 ## Usage
 

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 }
 
 jacoco {
-    toolVersion = "0.8.8"
+    toolVersion = "0.8.9"
 }
 
 jacocoTestReport {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=3.0.0
+version=3.1.0
 group=de.qaware.gradle.plugin
 fullName=XSD2Java Gradle Plugin
 displayName=XSD2Java Gradle Plugin

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/de/qaware/gradle/plugin/xsd2java/xjc/Xsd2JavaPlugin.groovy
+++ b/src/main/groovy/de/qaware/gradle/plugin/xsd2java/xjc/Xsd2JavaPlugin.groovy
@@ -71,14 +71,14 @@ class Xsd2JavaPlugin implements Plugin<Project> {
      * @param xjc The source set used to add the dependencies to.
      */
     private static void addsDependencies(Project project, SourceSet xjc) {
-        project.dependencies.add(xjc.implementationConfigurationName, "com.sun.xml.bind:jaxb-core:2.3.0.1")
-        project.dependencies.add(xjc.implementationConfigurationName, "com.sun.xml.bind:jaxb-impl:2.3.2")
-        project.dependencies.add(xjc.implementationConfigurationName, "javax.xml.bind:jaxb-api:2.3.1")
-        project.dependencies.add(xjc.implementationConfigurationName, "com.sun.xml.bind:jaxb-xjc:2.3.2")
+        project.dependencies.add(xjc.implementationConfigurationName, "org.glassfish.jaxb:jaxb-core:4.0.5")
+        project.dependencies.add(xjc.implementationConfigurationName, "org.glassfish.jaxb:jaxb-runtime:4.0.5")
+        project.dependencies.add(xjc.implementationConfigurationName, "jakarta.xml.bind:jakarta.xml.bind-api:4.0.2")
+        project.dependencies.add(xjc.implementationConfigurationName, "org.glassfish.jaxb:jaxb-xjc:4.0.5")
         project.dependencies.add(xjc.implementationConfigurationName, "javax.activation:activation:1.1.1")
 
-        project.dependencies.add('xsd2javaExtension', "com.github.jaxb-xew-plugin:jaxb-xew-plugin:1.9")
-        project.dependencies.add('xsd2javaExtension', "net.java.dev.jaxb2-commons:jaxb-fluent-api:2.1.8")
+        project.dependencies.add('xsd2javaExtension', "com.github.jaxb-xew-plugin:jaxb-xew-plugin:2.1")
+        project.dependencies.add('xsd2javaExtension', "org.jvnet.jaxb2_commons:jaxb2-fluent-api:3.0")
     }
 
     /**


### PR DESCRIPTION
The dependencies have been update so the classes are now generated with jakarta namespace for XML bindings.

The gradle wrapper and jacoco  have been also updated so it can be build with java 21.